### PR TITLE
Issue#10: PKGBUILD: changed the source file name for installation of …

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -46,7 +46,7 @@ package() {
 	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 	install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 	install -Dm644 macfand.1 "${pkgdir}/usr/share/man/man1/macfand.1"
-	install -Dm644 macfand.service.gen "${pkgdir}/usr/lib/systemd/system/macfand.service"
+	PREFIX=/usr sh macfand.service.gen > "${pkgdir}/usr/lib/systemd/system/macfand.service" && chmod 644 "${pkgdir}/usr/lib/systemd/system/macfand.service"
 
 	sudo perl ./util/updatemodel.pl "${pkgdir}/etc/macfand.conf" "${pkgdir}/usr/local/${pkgname/-git/}/machines/"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -46,7 +46,7 @@ package() {
 	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 	install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 	install -Dm644 macfand.1 "${pkgdir}/usr/share/man/man1/macfand.1"
-	install -Dm644 macfand.service "${pkgdir}/usr/lib/systemd/system/macfand.service"
+	install -Dm644 macfand.service.gen "${pkgdir}/usr/lib/systemd/system/macfand.service"
 
 	sudo perl ./util/updatemodel.pl "${pkgdir}/etc/macfand.conf" "${pkgdir}/usr/local/${pkgname/-git/}/machines/"
 }


### PR DESCRIPTION
…macfand.service from macfand.service to macfand.service.gen

When installing through yay, exit code 4 occurs as seen in the below log. Issue #10 speaks of this.
![macfand-git_ERROR](https://github.com/user-attachments/assets/241fb5f2-9977-4869-951b-848a0fd51e4a)

To test it apply:
```console
$ make
$ make install
```
